### PR TITLE
refactor(lab0): update function names to use all-caps for acronyms

### DIFF
--- a/lab0/README.md
+++ b/lab0/README.md
@@ -94,15 +94,15 @@ go test -v -race -timeout 30s ./...
 2024/06/14 10:18:04 Handle Request from [127.0.0.1:43510]
 --- PASS: TestTcpFunction (5.03s)
 PASS
-2024/06/14 10:18:04 Client [127.0.0.1:43502[] Error: EOF
-2024/06/14 10:18:04 Client [127.0.0.1:43494[] Error: EOF
-2024/06/14 10:18:04 Client [127.0.0.1:43480[] Error: EOF
-2024/06/14 10:18:04 Client [127.0.0.1:43468[] Error: EOF
-2024/06/14 10:18:04 Client [127.0.0.1:43460[] Error: EOF
-2024/06/14 10:18:04 Client [127.0.0.1:43510[] Error: EOF
-2024/06/14 10:18:04 Client [127.0.0.1:43428[] Error: EOF
-2024/06/14 10:18:04 Client [127.0.0.1:43440[] Error: EOF
-2024/06/14 10:18:04 Client [127.0.0.1:43446[] Error: EOF
-2024/06/14 10:18:04 Client [127.0.0.1:43456[] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43502] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43494] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43480] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43468] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43460] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43510] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43428] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43440] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43446] Error: EOF
+2024/06/14 10:18:04 Client [127.0.0.1:43456] Error: EOF
 ok      github.com/ianchen0119/free5GLab/lab0   6.050s
 ```

--- a/lab0/ans/tcp.go
+++ b/lab0/ans/tcp.go
@@ -11,7 +11,7 @@ type listenerInterface func(string, int, handlerInterface)
 
 type handlerInterface func(conn net.Conn)
 
-func TcpListener(host string, port int, handler handlerInterface) {
+func TCPListener(host string, port int, handler handlerInterface) {
 	server, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		log.Fatalf("Server can't listening on port %d: %v", port, err)
@@ -31,7 +31,7 @@ func TcpListener(host string, port int, handler handlerInterface) {
 	}
 }
 
-func TcpHandler(conn net.Conn) {
+func TCPHandler(conn net.Conn) {
 	defer conn.Close()
 	clientAddr := conn.RemoteAddr().String()
 	log.Printf("Handle Request from [%s]", clientAddr)
@@ -39,7 +39,7 @@ func TcpHandler(conn net.Conn) {
 	for {
 		data, err := bufio.NewReader(conn).ReadString('\n')
 		if err != nil {
-			log.Printf("Client [%s[] Error: %v", clientAddr, err)
+			log.Printf("Client [%s] Error: %v", clientAddr, err)
 			return
 		}
 		_, err = conn.Write([]byte(data))

--- a/lab0/tcp.go
+++ b/lab0/tcp.go
@@ -8,10 +8,8 @@ type listenerInterface func(string, int, handlerInterface)
 
 type handlerInterface func(conn net.Conn)
 
-func TcpListener(host string, port int, handler handlerInterface) {
-
+func TCPListener(host string, port int, handler handlerInterface) {
 }
 
-func TcpHandler(conn net.Conn) {
-
+func TCPHandler(conn net.Conn) {
 }

--- a/lab0/tcp_test.go
+++ b/lab0/tcp_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestTcpFunction(t *testing.T) {
 	// Type Assertion
-	var _ listenerInterface = TcpListener
-	var _ handlerInterface = TcpHandler
+	var _ listenerInterface = TCPListener
+	var _ handlerInterface = TCPHandler
 
-	go TcpListener("127.0.0.1", 8080, TcpHandler)
+	go TCPListener("127.0.0.1", 8080, TCPHandler)
 
 	time.Sleep(5 * time.Second)
 
@@ -38,7 +38,6 @@ func TestTcpFunction(t *testing.T) {
 
 			connectionSlice = append(connectionSlice, conn)
 		}()
-
 	}
 
 	for _, conn := range connectionSlice {


### PR DESCRIPTION
This commit refactors function names to follow Go's naming convention, where acronyms are written in all capitals.

Refs:
- Go Code Review Comments: https://go.dev/wiki/CodeReviewComments#initialisms
- Go naming talk by Andrew Gerrand: https://go.dev/talks/2014/names.slide#5
- Effective Go guide: https://golang.org/doc/effective_go#mixed-caps