### PR TITLE
fix: typo of cb

### DIFF
--- a/lab2/README.md
+++ b/lab2/README.md
@@ -70,7 +70,7 @@ struct sk_buff {
     struct sock             *sk; // This field is needed for socket-related data at L4. It is null if the host is neither the destination nor the source.
     struct net_device       *dev;
 
-    char                    cb[48] __aligned(8); // Control buffer
+    char                    cb[48] __aligned(8); // Control block
 
     unsigned long           _skb_refdst;
     void                    (*destructor)(struct sk_buff *skb);
@@ -150,7 +150,7 @@ struct sk_buff {
 
     The virtual driver will select a specific device and then set the dev field to point to this net_device structure. Therefore, this value changes during the packet processing.
 
-2. cb: control buffer
+2. cb: control block
     1. Each layer has its private information storage here, storing temporary data.
     2. For example:
         - IP

--- a/lab2/ans.md
+++ b/lab2/ans.md
@@ -10,7 +10,7 @@ sk_buff stores a wealth of information that covers various aspects of a network 
     1. next: Pointer to the next buffer in the list.
     2. prev: Pointer to the previous buffer in the list.
     3. dev: Pointer to the network device.
-    4. cb[48]: Control buffer, used for various control information.
+    4. cb[48]: Control block, used for various control information.
     _skb_refdst: Reference to the destination entry.
     destructor: Pointer to the function that will be called when the buffer is destroyed.
     5. head: Pointer to the start of the buffer.


### PR DESCRIPTION
Correct the explanation of "cb" (control block). Originally, do not interpret "cb" as "control buffer."